### PR TITLE
Set active object if active_object is None

### DIFF
--- a/quicksnap.py
+++ b/quicksnap.py
@@ -713,6 +713,8 @@ class QuickVertexSnapOperator(bpy.types.Operator):
 
         # Revert mode and selection
         if self.object_mode:
+            if context.active_object is None:
+                context.view_layer.objects.active = context.selected_objects[0]
             bpy.ops.object.mode_set(mode='OBJECT')
 
         if self.no_selection:


### PR DESCRIPTION
Here you could make the active object, the one you clicked on, but this problem is rare, so I do not think it is necessary to bother