### PR TITLE
Update shader definition for the addon to work on blender v3.5 and v3.6 on Mac/Metal

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     "name": "QuickSnap",
     "author": "Julien Heijmans",
     "blender": (2, 80, 0),
-    'version': (1, 4, 1),
+    'version': (1, 4, 2),
     "category": "3D View",
     "description": "Quickly snap objects/vertices/curve points",
     "warning": "",

--- a/quicksnap_render.py
+++ b/quicksnap_render.py
@@ -24,43 +24,49 @@ shader_2d_uniform_color = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
 shader_3d_uniform_color = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
 shader_3d_smooth_color = gpu.shader.from_builtin('3D_SMOOTH_COLOR')
 
-shader_2d_image_vertex = '''
+shader_2d_image_info = gpu.types.GPUShaderCreateInfo()
+#interface
+shader_2d_image_interface = gpu.types.GPUStageInterfaceInfo("my_interface")
+shader_2d_image_interface.smooth('VEC2', "uvInterp")
+# vertex shader info/interface
+shader_2d_image_info.vertex_in(0, 'VEC2', "texCoord")
+shader_2d_image_info.vertex_in(1, 'VEC2', "pos")
+shader_2d_image_info.push_constant('MAT4', "ModelViewProjectionMatrix")
 
-    uniform mat4 ModelViewProjectionMatrix;
+# fragment shader info/interface
+shader_2d_image_info.push_constant('VEC4', "u_Color")
+shader_2d_image_info.push_constant('VEC4', "u_Color_bg")
+shader_2d_image_info.push_constant('FLOAT', "u_Fade")
+shader_2d_image_info.sampler(0, 'FLOAT_2D', "u_Image")
 
-    in vec2 texCoord;
-    in vec2 pos;
-    out vec2 texCoord_interp;
-
+shader_2d_image_info.vertex_out(shader_2d_image_interface)
+shader_2d_image_info.vertex_source(
+    '''
     void main()
     {
       gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0f, 1.0f);
       gl_Position.z = 1.0;
-      texCoord_interp = texCoord;
+      uvInterp = texCoord;
     }
-
-'''
-shader_2d_image_fragment = '''
-    uniform vec4 color;
-    uniform vec4 color_bg;
-    uniform float fade;
-    in vec2 texCoord_interp;
-    out vec4 fragColor;
-
-    uniform sampler2D image;
-
+    ''')
+shader_2d_image_info.fragment_out(0, 'VEC4', 'fragColor')
+shader_2d_image_info.fragment_source(
+    '''
     void main()
     {
-      vec4 texture_sampled=texture(image, texCoord_interp);
+      vec4 texture_sampled=texture(u_Image, uvInterp);
       if(texture_sampled.a>0.6)
-        fragColor = color * texture_sampled;
+        fragColor = u_Color * texture_sampled;
       else
-        fragColor = color_bg * texture_sampled;
-      fragColor=vec4(fragColor.r, fragColor.g, fragColor.b, fragColor.a * smoothstep(0,1,fade));
+        fragColor = u_Color_bg * texture_sampled;
+      fragColor=vec4(fragColor.r, fragColor.g, fragColor.b, fragColor.a * smoothstep(0,1,u_Fade));
     }
 
-'''
-shader_2d_image_color = gpu.types.GPUShader(shader_2d_image_vertex, shader_2d_image_fragment)
+    ''')
+# shader_2d_image_color = gpu.types.GPUShader(shader_2d_image_vertex, shader_2d_image_fragment)
+shader_2d_image_color = gpu.shader.create_from_info(shader_2d_image_info)
+del shader_2d_image_info
+del shader_2d_image_interface
 icons = {}
 
 
@@ -131,10 +137,10 @@ def draw_image(self, position_x=100, position_y=100, size=20, image='MISSING', c
         },
     )
     shader_2d_image_color.bind()
-    shader_2d_image_color.uniform_float("color", color)
-    shader_2d_image_color.uniform_float("color_bg", color_bg)
-    shader_2d_image_color.uniform_float("fade", fade)
-    shader_2d_image_color.uniform_sampler("image", icons[image])
+    shader_2d_image_color.uniform_float("u_Color", color)
+    shader_2d_image_color.uniform_float("u_Color_bg", color_bg)
+    shader_2d_image_color.uniform_float("u_Fade", fade)
+    shader_2d_image_color.uniform_sampler("u_Image", icons[image])
     batch.draw(shader_2d_image_color)
 
     # if image and self.icons[image].gl_load():


### PR DESCRIPTION
Update shader definition for the addon to work on blender v3.5 and v3.6 on Mac/Metal.
Removed all bgl calls and replaced with use of gpu api.