### PR TITLE
1.4.7 Minor: Fix line width, expose square size.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     "name": "QuickSnap",
     "author": "Julien Heijmans",
     "blender": (2, 93, 0),
-    'version': (1, 4, 6),
+    'version': (1, 4, 7),
     "category": "3D View",
     "description": "Quickly snap objects/vertices/curve points",
     "warning": "",

--- a/quicksnap.py
+++ b/quicksnap.py
@@ -864,7 +864,8 @@ class QuickVertexSnapPreference(bpy.types.AddonPreferences):
     display_target_wireframe: bpy.props.BoolProperty(name="Display target object wireframe", default=True)
     highlight_target_vertex_edges: bpy.props.BoolProperty(name="Enable highlighting of target vertex edges*",
                                                           default=True)
-    edge_highlight_width: bpy.props.IntProperty(name="Highlight Width", default=2, min=1, max=5)
+    edge_highlight_width: bpy.props.IntProperty(name="Highlight Width", default=2, min=1, max=10)
+    selection_square_size: bpy.props.IntProperty(name="Selection Square Size", default=7, min=5, max=15)
     edge_highlight_color_source: bpy.props.FloatVectorProperty(
         name="Highlight Color (Selected object)",
         subtype='COLOR',
@@ -960,10 +961,12 @@ class QuickVertexSnapPreference(bpy.types.AddonPreferences):
         col.prop(self, "draw_rubberband")
         col.prop(self, "display_target_wireframe")
         col.prop(self, "display_potential_target_points")
+        col.prop(self, "selection_square_size")
+        col.separator()
         col.prop(self, "snap_target_type_icon")
         col.separator()
         container = col.box().column()
-        container.label(text="Target Edge Highlight*:")
+        container.label(text="Selection/Target Highlight*:")
         container.prop(self, "highlight_target_vertex_edges")
         if self.highlight_target_vertex_edges:
             container.prop(self, "edge_highlight_width")

--- a/quicksnap_render.py
+++ b/quicksnap_render.py
@@ -12,7 +12,6 @@ from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
 
 from .quicksnap_utils import State
-from .quicksnap_utils import remap
 from .quicksnap_utils import dump
 if bpy.app.version >= (3, 4, 0):
     from .quicksnap_shader_gpu_module import shader_2d_image_color, shader_2d_uniform_color, shader_3d_uniform_color, shader_3d_smooth_color, shader_3d_polyline_smooth_color
@@ -257,8 +256,7 @@ def draw_callback_2d(self, context):
     """
         Draw all QuickSnap 2D UI: Icons, source/target square. rubberband/
     """
-    square_width=7*remap(1,5,1,2,self.settings.edge_highlight_width)
-    print(f"square wiidth:{square_width}")
+    square_width=self.settings.selection_square_size
     current_time = time.time()
     if self.settings.snap_target_type_icon != 'NEVER' and current_time < self.icon_display_time + icon_display_duration or self.settings.snap_target_type_icon == 'ALWAYS':
         fade = 1

--- a/quicksnap_render.py
+++ b/quicksnap_render.py
@@ -12,6 +12,7 @@ from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
 
 from .quicksnap_utils import State
+from .quicksnap_utils import remap
 from .quicksnap_utils import dump
 if bpy.app.version >= (3, 4, 0):
     from .quicksnap_shader_gpu_module import shader_2d_image_color, shader_2d_uniform_color, shader_3d_uniform_color, shader_3d_smooth_color, shader_3d_polyline_smooth_color
@@ -150,8 +151,6 @@ def draw_line_3d_smooth_blend(source, target, color_a=(1, 0, 0, 1), color_b=(0, 
         Draw a smooth blend line in the viewport.
     """
     if bpy.app.version >= (3, 4, 0):
-        if line_width != 1:
-            gpu.state.line_width_set(line_width)
         gpu.state.blend_set("ALPHA")
         if depth_test:
             gpu.state.depth_test_set("LESS")
@@ -164,8 +163,7 @@ def draw_line_3d_smooth_blend(source, target, color_a=(1, 0, 0, 1), color_b=(0, 
         shader_3d_polyline_smooth_color.uniform_float("lineWidth", line_width)
         shader_3d_polyline_smooth_color.bind()
         batch.draw(shader_3d_polyline_smooth_color)
-        if line_width != 1:
-            gpu.state.line_width_set(1)
+
         gpu.state.blend_set("NONE")
         if depth_test:
             gpu.state.depth_test_set("NONE")
@@ -254,10 +252,13 @@ icon_display_duration = 2
 fade_duration = 0.2
 
 
+
 def draw_callback_2d(self, context):
     """
         Draw all QuickSnap 2D UI: Icons, source/target square. rubberband/
     """
+    square_width=7*remap(1,5,1,2,self.settings.edge_highlight_width)
+    print(f"square wiidth:{square_width}")
     current_time = time.time()
     if self.settings.snap_target_type_icon != 'NEVER' and current_time < self.icon_display_time + icon_display_duration or self.settings.snap_target_type_icon == 'ALWAYS':
         fade = 1
@@ -273,6 +274,7 @@ def draw_callback_2d(self, context):
                        image=self.snapdata_target.snap_type, color=icon_color[self.current_state], fade=fade)
 
     if self.closest_source_id >= 0:
+        
         source_position_3d = self.snapdata_source.world_space[self.closest_source_id]
         source_position_2d = bpy_extras.view3d_utils.location_3d_to_region_2d(context.region,
                                                                               context.space_data.region_3d,
@@ -280,7 +282,7 @@ def draw_callback_2d(self, context):
         source_x, source_y = source_position_2d[0], source_position_2d[1]
         # Source selection
         if self.current_state == State.IDLE:  # no source picked
-            draw_square_2d(source_x, source_y, 7)
+            draw_square_2d(source_x, source_y, square_width)
 
         else:
             # logger.info(f"source picked . self.target2d={self.target2d} -  self.settings.draw_rubberband={self.settings.draw_rubberband}")
@@ -289,7 +291,7 @@ def draw_callback_2d(self, context):
             else:
                 color = (1, 1, 0, 1)
             if self.settings.draw_rubberband:
-                draw_square_2d(source_x, source_y, 7, color=color)
+                draw_square_2d(source_x, source_y, square_width, color=color)
             # if self.target2d:
             if self.target is not None:
                 target_position_2d = bpy_extras.view3d_utils.location_3d_to_region_2d(context.region,
@@ -303,13 +305,13 @@ def draw_callback_2d(self, context):
                         context.space_data.region_3d,
                         self.snapdata_target.world_space[self.closest_target_id])
                     if len(self.snapping) > 0:
-                        draw_square_2d(target_x, target_y, 7,
+                        draw_square_2d(target_x, target_y, square_width,
                                        color=color, line_width=0)  # dot to target
-                        draw_square_2d(snap_target_2d[0], snap_target_2d[1], 7, color=color)  # square to snapped point
+                        draw_square_2d(snap_target_2d[0], snap_target_2d[1], square_width, color=color)  # square to snapped point
                     else:
-                        draw_square_2d(target_x, target_y, 7, color=color)
+                        draw_square_2d(target_x, target_y, square_width, color=color)
                 else:
-                    draw_square_2d(target_x, target_y, 7, color=color,
+                    draw_square_2d(target_x, target_y, square_width, color=color,
                                    line_width=0)  # dot to target
 
                 if self.settings.draw_rubberband:
@@ -317,7 +319,7 @@ def draw_callback_2d(self, context):
 
     elif self.current_state == State.IDLE:
         # Draw grey square when tool is enabled, additional indication that the tool is active
-        draw_square_2d(self.mouse_position[0], self.mouse_position[1], 7, color=(1, 1, 1, 0.3), point_width=0)
+        draw_square_2d(self.mouse_position[0], self.mouse_position[1], square_width, color=(1, 1, 1, 0.3), point_width=0)
 
 
 def draw_snap_axis(self, context):

--- a/quicksnap_utils.py
+++ b/quicksnap_utils.py
@@ -425,31 +425,5 @@ def set_select_all_points(object_names, selected=False):
                 spline.bezier_points.foreach_set('select_control_point', np.full(len(spline.bezier_points), selected))
             pass
 
-def lerp(a: float, b: float, t: float) -> float:
-    """Linear interpolate on the scale given by a to b, using t as the point on that scale.
-    Examples
-    --------
-        50 == lerp(0, 100, 0.5)
-        4.2 == lerp(1, 5, 0.8)
-    """
-    return (1 - t) * a + t * b
 
-def inv_lerp(a: float, b: float, v: float) -> float:
-    """Inverse Linar Interpolation, get the fraction between a and b on which v resides.
-    Examples
-    --------
-        0.5 == inv_lerp(0, 100, 50)
-        0.8 == inv_lerp(1, 5, 4.2)
-    """
-    return (v - a) / (b - a)
 
-def remap(i_min: float, i_max: float, o_min: float, o_max: float, v: float) -> float:
-    """Remap values from one linear scale to another, a combination of lerp and inv_lerp.
-    i_min and i_max are the scale on which the original value resides,
-    o_min and o_max are the scale to which it should be mapped.
-    Examples
-    --------
-        45 == remap(0, 100, 40, 50, 50)
-        6.2 == remap(1, 5, 3, 7, 4.2)
-    """
-    return lerp(o_min, o_max, inv_lerp(i_min, i_max, v))

--- a/quicksnap_utils.py
+++ b/quicksnap_utils.py
@@ -424,3 +424,32 @@ def set_select_all_points(object_names, selected=False):
                 spline.points.foreach_set('select', np.full(len(spline.points), selected))
                 spline.bezier_points.foreach_set('select_control_point', np.full(len(spline.bezier_points), selected))
             pass
+
+def lerp(a: float, b: float, t: float) -> float:
+    """Linear interpolate on the scale given by a to b, using t as the point on that scale.
+    Examples
+    --------
+        50 == lerp(0, 100, 0.5)
+        4.2 == lerp(1, 5, 0.8)
+    """
+    return (1 - t) * a + t * b
+
+def inv_lerp(a: float, b: float, v: float) -> float:
+    """Inverse Linar Interpolation, get the fraction between a and b on which v resides.
+    Examples
+    --------
+        0.5 == inv_lerp(0, 100, 50)
+        0.8 == inv_lerp(1, 5, 4.2)
+    """
+    return (v - a) / (b - a)
+
+def remap(i_min: float, i_max: float, o_min: float, o_max: float, v: float) -> float:
+    """Remap values from one linear scale to another, a combination of lerp and inv_lerp.
+    i_min and i_max are the scale on which the original value resides,
+    o_min and o_max are the scale to which it should be mapped.
+    Examples
+    --------
+        45 == remap(0, 100, 40, 50, 50)
+        6.2 == remap(1, 5, 3, 7, 4.2)
+    """
+    return lerp(o_min, o_max, inv_lerp(i_min, i_max, v))


### PR DESCRIPTION
Line width was bugged due to some OpenGL line width call that was removed. Adding that back and exposing selection square size, for those with big screen resolutions.

Some [issue ](https://github.com/JulienHeijmans/quicksnap/issues/69) still exist on MacOS silicon. Looking into it, but hard to fix for me as I can't repro the issue on my machine.