### PR TITLE
Fixing the constructor breaking change for all objects - invoke supoe…

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -55,8 +55,8 @@ class SingletonUpdater:
     needed throughout the addon. It implements all the interfaces for running
     updates.
     """
-    def __init__(self):
-
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs  )
         self._engine = GithubEngine()
         self._user = None
         self._repo = None
@@ -1635,7 +1635,8 @@ class SingletonUpdater:
 class BitbucketEngine:
     """Integration to Bitbucket API for git-formatted repositories"""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://api.bitbucket.org'
         self.token = None
         self.name = "bitbucket"
@@ -1669,7 +1670,8 @@ class BitbucketEngine:
 class GithubEngine:
     """Integration to Github API"""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://api.github.com'
         self.token = None
         self.name = "github"
@@ -1699,7 +1701,8 @@ class GithubEngine:
 class GitlabEngine:
     """Integration to GitLab API"""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://gitlab.com'
         self.token = None
         self.name = "gitlab"

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -43,7 +43,8 @@ except Exception as e:
     class SingletonUpdaterNone(object):
         """Fake, bare minimum fields and functions for the updater object."""
 
-        def __init__(self):
+        def __init__(self, *args, **kwargs):
+            super(SingletonUpdaterNone, self).__init__(*args, **kwargs)
             self.invalid_updater = True  # Used to distinguish bad install.
 
             self.addon = None

--- a/quicksnap.py
+++ b/quicksnap.py
@@ -370,7 +370,8 @@ class QuickVertexSnapOperator(bpy.types.Operator):
             self.target2d = quicksnap_utils.transform_worldspace_coord2d(self.target, region,
                                                                          context.space_data.region_3d)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.icons = None
         self.icon_display_time = 0
         self.view_distance = None

--- a/quicksnap_snapdata.py
+++ b/quicksnap_snapdata.py
@@ -28,6 +28,7 @@ class ObjectPointData:
     def __init__(self, obj, object_id, perspective_matrix, width, height, width_half, height_half, view_location,
                  check_select=False,
                  filter_selected=True, snap_type='POINTS'):
+        super().__init__()
         """Initialize the ObjectPointData, calculates WorldSpace/ScreenSpace coordinates from local space coordinates
 
         Args:
@@ -215,6 +216,7 @@ class SnapData:
 
     def __init__(self, context, region, settings, selected_meshes, scene_meshes=None, is_origin=False,
                  no_selection=False):
+        super().__init__()
         self.no_selection = no_selection
         self.settings = settings
         self.is_origin_snapdata = is_origin


### PR DESCRIPTION
Blender 4.4 introduced a breaking change - all def `__init__` requires to call `super.__init()__ `
See https://developer.blender.org/docs/release_notes/4.4/python_api/#breaking-changes
This fix was tested with Blender 4.4.