### PR TITLE
Fix the __init__ constructors to call the parent matching function for blender 4.4

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -56,6 +56,7 @@ class SingletonUpdater:
     updates.
     """
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._engine = GithubEngine()
         self._user = None
         self._repo = None
@@ -1635,6 +1636,7 @@ class BitbucketEngine:
     """Integration to Bitbucket API for git-formatted repositories"""
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://api.bitbucket.org'
         self.token = None
         self.name = "bitbucket"
@@ -1669,6 +1671,7 @@ class GithubEngine:
     """Integration to Github API"""
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://api.github.com'
         self.token = None
         self.name = "github"
@@ -1699,6 +1702,7 @@ class GitlabEngine:
     """Integration to GitLab API"""
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.api_url = 'https://gitlab.com'
         self.token = None
         self.name = "gitlab"

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -44,6 +44,7 @@ except Exception as e:
         """Fake, bare minimum fields and functions for the updater object."""
 
         def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
             self.invalid_updater = True  # Used to distinguish bad install.
 
             self.addon = None

--- a/quicksnap_snapdata.py
+++ b/quicksnap_snapdata.py
@@ -27,7 +27,7 @@ class ObjectPointData:
 
     def __init__(self, obj, object_id, perspective_matrix, width, height, width_half, height_half, view_location,
                  check_select=False,
-                 filter_selected=True, snap_type='POINTS'):
+                 filter_selected=True, snap_type='POINTS', *args, **kwargs):
         """Initialize the ObjectPointData, calculates WorldSpace/ScreenSpace coordinates from local space coordinates
 
         Args:
@@ -39,6 +39,7 @@ class ObjectPointData:
             check_select: If true filter points base on point selection
             filter_selected: If true includes only selected points, if false include only un-selected points
         """
+        super().__init__(*args, **kwargs)
         self.completed = False
         # logger.debug(f"ObjectPointData {obj.name}- check_select={check_select} - filter_selected={filter_selected}")
         matrix_world = obj.matrix_world
@@ -214,7 +215,8 @@ class SnapData:
     """
 
     def __init__(self, context, region, settings, selected_meshes, scene_meshes=None, is_origin=False,
-                 no_selection=False):
+                 no_selection=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.no_selection = no_selection
         self.settings = settings
         self.is_origin_snapdata = is_origin


### PR DESCRIPTION
This pull request is a fix for the issue #82.
The issue and the fix was based on the Blender 4.4: Python API (Breaking changes -> Subclassing Blender Types) in this link:
https://developer.blender.org/docs/release_notes/4.4/python_api/#blender-44-python-api